### PR TITLE
Fix README: fitParent must be Boolean instead of Number

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ export default {
 | height      | Number, String | 360     | `iframe` pixel height                                    |
 | resize      | Boolean        | false   | `iframe` will proportionally scale height with its width |
 | resizeDelay | Number         | 200     | Delay in milliseconds before running resize callback     |
-| fitParent   | Number         | false    | `iframe` will use its parent's width                     |
+| fitParent   | Boolean        | false   | `iframe` will use its parent's width                     |
 
 #### Tips for Resizing
 


### PR DESCRIPTION
According to [the source](https://github.com/anteriovieira/vue-youtube/blob/2aa7978573c5fd10c38251f0b964a63856f589ac/src/vue-youtube.js#L35) `fitParent` must be Boolean instead of Number.