### PR TITLE
export getIdFromUrl function

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,15 @@ iframe {
   }
 ...
 ```
+or
+```js
+import { getIdFromUrl } from 'vue-youtube'
 
+const myFunction = (url) => {
+  const youtubeId = getIdFromUrl(url)
+  // ...
+}
+```
 ## License
 
 [MIT](http://opensource.org/licenses/MIT)

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
-import GetYoutubeId from 'get-youtube-id'
+import getIdFromUrl from 'get-youtube-id'
 import Youtube from './vue-youtube'
 
 function plugin (Vue) {
   Vue.prototype.$youtube = {
-    getIdFromUrl: GetYoutubeId
+    getIdFromUrl
   }
 
   Vue.component('youtube', Youtube)
@@ -18,5 +18,6 @@ const version = '__VERSION__'
 
 export {
   Youtube,
+  getIdFromUrl,
   version
 }


### PR DESCRIPTION
This PR allows to use the URL parsing function also when the plugin is not installed, e.g. when importing and using just the component. Or using the function outside of a Vue component.

I think if `get-youtube-id` is already packaged with your component it should also be fully accessible to avoid duplicate imports.