### PR TITLE
#41 Add nocookie prop

### DIFF
--- a/src/vue-youtube.js
+++ b/src/vue-youtube.js
@@ -31,6 +31,10 @@ export default {
       type: Number,
       default: 100
     },
+    nocookie: {
+      type: Boolean,
+      default: false
+    },
     fitParent: {
       type: Boolean,
       default: false
@@ -129,8 +133,11 @@ export default {
     window.YTConfig = {
       host: 'https://www.youtube.com/iframe_api'
     }
+    
+    const host = this.nocookie ? 'https://www.youtube-nocookie.com' : 'https://www.youtube.com'
 
     this.player = player(this.$el, {
+      host,
       width: this.width,
       height: this.height,
       videoId: this.videoId,


### PR DESCRIPTION
# Problem
To use Youtube GDPR compliant, I don't want to use the default config of the youtube player. Rather use the nocookie-domain:

# direct implementation:

```JS
var player;
var tag = document.createElement('script');
tag.src = "https://www.youtube.com/iframe_api";
      	var firstScriptTag = document.getElementsByTagName('script')[0];
      	firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);

player = new YT.Player('player1', {
	    wmode: 'transparent',
            host: 'https://www.youtube-nocookie.com',
	    playerVars:{
		   wmode: 'transparent',
		   showinfo:0,
		   autohide:1,
            },
	  videoId: YOUR_VID_ID,
	  events: {
		  'onReady': onPlayerReady
		}
        });
```

[https://portalzine.de/dev/api/youtube-iframe-api-and-cookieless-domain-solution-gdpr-dsgvo/](https://portalzine.de/dev/api/youtube-iframe-api-and-cookieless-domain-solution-gdpr-dsgvo/)

# How to fix?

Add a new prop `nocookie` boolean flag and set the host accordingly.